### PR TITLE
adding timestep option for retrieving data

### DIFF
--- a/RCode/NEFI/get_data.R
+++ b/RCode/NEFI/get_data.R
@@ -1,8 +1,9 @@
 # function for pulling data and getting it into a usable format 
 
 require(dplyr)
+require(rlang)
 
-get_data <- function(cal_time_start, cal_time_end, forecast_time_end, sites){
+get_data <- function(cal_time_start, cal_time_end, forecast_time_end, model_timestep = 1, sites){
   
   gleo <- read.csv('Datasets/Sunapee/R Work/Level 1/All_Sites_Gloeo.csv', stringsAsFactors = F) %>%
     as_data_frame() %>% 
@@ -21,10 +22,21 @@ get_data <- function(cal_time_start, cal_time_end, forecast_time_end, sites){
   
   data <- left_join(gleo, wtr, by = c('week', 'year', 'site')) 
   
-  #filling in rows to make it daily time step 
-  all_dates <- data_frame(date = seq(min(data$date), max(data$date), by= 'day'))
+  add_cols = colnames(select(data, -date))
   
-  data <- left_join(all_dates, data, by = 'date') 
+  #filling in rows to make it daily time step ; or specified model timestep 
+  all_dates <- data_frame(date = seq(min(data$date), max(data$date), by= paste(model_timestep, 'day')))
+  
+  other_cols = lapply(add_cols, function(col){
+        mutate(all_dates, !!col := NA)
+    }) %>% bind_cols() %>% select(-contains('date'))
+  
+  all_dates <- bind_cols(all_dates, other_cols) %>%
+    select(colnames(data))
+  
+  data <- bind_rows(data, all_dates) %>%
+    dplyr::filter(!duplicated(date)) %>%
+    arrange(date)
   
   cal <- data %>%
     dplyr::filter(date > as.Date(cal_time_start), date < as.Date(cal_time_end)) 

--- a/RCode/NEFI/get_data.R
+++ b/RCode/NEFI/get_data.R
@@ -5,7 +5,7 @@ require(rlang)
 
 get_data <- function(cal_time_start, cal_time_end, forecast_time_end, model_timestep = 1, sites){
   
-  gleo <- read.csv('Datasets/Sunapee/R Work/Level 1/All_Sites_Gloeo.csv', stringsAsFactors = F) %>%
+  gleo <- read.csv('Datasets/Sunapee/SummarizedData/All_Sites_Gloeo_light_wtrtemp.csv', stringsAsFactors = F) %>%
     as_data_frame() %>% 
     mutate(date = lapply(date, function(date){as.Date(strsplit(date, 'T')[[1]][1]) %>% as_data_frame()}) %>%  # changing date format to date 
     bind_rows() %>%
@@ -15,12 +15,14 @@ get_data <- function(cal_time_start, cal_time_end, forecast_time_end, model_time
     dplyr::filter(site %in% sites) 
 
   
-  # temperature data 
-  wtr <- read.csv('Datasets/Sunapee/R Work/Level 1/wtr_temp_long_weekly_summary.csv', stringsAsFactors = F) %>%
-    select(-X) %>%
-    mutate(site = tolower(site)) 
+  # # temperature data 
+  # wtr <- read.csv('Datasets/Sunapee/Level1/wtr_temp_long_weekly_summary.csv', stringsAsFactors = F) %>%
+  #   select(-X) %>%
+  #   mutate(site = tolower(site)) 
+  # 
+  # data <- left_join(gleo, wtr, by = c('week', 'year', 'site')) 
   
-  data <- left_join(gleo, wtr, by = c('week', 'year', 'site')) 
+  data <- gleo
   
   add_cols = colnames(select(data, -date))
   

--- a/RCode/NEFI/model_wrapper.R
+++ b/RCode/NEFI/model_wrapper.R
@@ -5,13 +5,18 @@ source('RCode/NEFI/bayes_models.R')
 
 # library(R2jags)
 
-cal_time_start <- '1990-01-01' 
-cal_time_end <- '2010-01-01' 
+cal_time_start <- '2010-05-01' 
+cal_time_end <- '2010-10-01' 
 forecast_time_end <- '2016-01-01' 
 sites <- c('midge') 
+model_timestep <- 1 # number of days between model estimates 
 
-cal_data <- get_data(cal_time_start, cal_time_end, forecast_time_end, sites)$cal # get the data
-forecast_data <- get_data(cal_time_start, cal_time_end, forecast_time_end, sites)$forecast 
+# have to figure out if we want regular time steps; if so, some model timesteps will get rid of data (e.g. 3 day timestep will not use a lot of weekly data)
+
+data <- get_data(cal_time_start, cal_time_end, forecast_time_end, model_timestep, sites) # get the data
+cal_data <- data$cal 
+forecast_data <- data$forecast 
+
 all_data <- rbind(cal_data, forecast_data) %>%
   mutate(data_type = c(rep('cal_data', nrow(cal_data)), rep('forecast_data', nrow(forecast_data)))) %>%
   mutate(totalperL = case_when(data_type == 'cal_data' ~ totalperL,

--- a/RCode/NEFI/model_wrapper.R
+++ b/RCode/NEFI/model_wrapper.R
@@ -9,7 +9,7 @@ cal_time_start <- '2010-05-01'
 cal_time_end <- '2010-10-01' 
 forecast_time_end <- '2016-01-01' 
 sites <- c('midge') 
-model_timestep <- 1 # number of days between model estimates 
+model_timestep <- 3 # number of days between model estimates 
 
 # have to figure out if we want regular time steps; if so, some model timesteps will get rid of data (e.g. 3 day timestep will not use a lot of weekly data)
 


### PR DESCRIPTION
Even though we're going to use synthetic data in model development for now, the topic of model timestep came up a couple of times during the call a couple times so I made it an option in the `get_data` function. @wbeck1990 @jabrent @immccull95, not sure if you were using this function, but just a heads up, there's another argument in there now `model_timestep`, which is default to 1 day, but you can specify whatever you want. 

If we choose something other than 1 day model timestep, we'll have to decide whether we want regular timesteps in the model or not use some of the sample time points because the sample time points may not line up with every timestep (e.g. 3 day model timestep will not use some of the weekly sample time points). 

right now, `get_data` keeps all the data and doesn't care about irregular model timestep. A 1 day timestep keeps _all_ the data _and_ has regular time steps (model timestep show as vertical lines): 
![image](https://user-images.githubusercontent.com/4825431/46556047-01cd6180-c8ab-11e8-8cf8-bab0f7ff1e13.png)

but choosing a 3 day model timestep produces irregular timesteps, however keeps all the data as of now: 
![image](https://user-images.githubusercontent.com/4825431/46556453-4d343f80-c8ac-11e8-8e8a-2597d54bdefb.png)



