### PR TITLE
Adding uncertainty partitioning example 

### DIFF
--- a/RCode/helper_functions/plug_n_play_functions.R
+++ b/RCode/helper_functions/plug_n_play_functions.R
@@ -3,21 +3,40 @@
 # WB Updates
 
 
-plug_n_play_data <- function(start_date, end_date, sites, model_timestep, fill_dates){
+plug_n_play_data <- function(start_date, end_date, sites, model_timestep, fill_dates, forecast = FALSE, forecast_end_date){
   
   sites = tolower(site) 
   
-  Data = get_data(cal_time_start = start_date, 
-                  cal_time_end = end_date, 
-                  model_timestep = model_timestep, # model timestep in days if filling in dates
-                  fill_dates = fill_dates,  # T/F for filling in dates w/o observations with NA's 
-                  sites = sites) %>%
-    mutate(daylength = daylength(43.4802, date))
-  
+  if(forecast){
+    Data = get_data(cal_time_start = start_date, 
+                    cal_time_end = end_date, 
+                    model_timestep = model_timestep, # model timestep in days if filling in dates
+                    fill_dates = fill_dates,  # T/F for filling in dates w/o observations with NA's 
+                    forecast = forecast, 
+                    forecast_time_end = forecast_end_date,
+                    sites = sites)
+    
+    Data_cal = Data$cal %>% 
+      mutate(daylength = daylength(43.4802, date))
+    
+    Data_forecast = Data$forecast %>%
+      mutate(daylength = daylength(43.4802, date))
+    
+    return(list(cal = Data_cal, forecast = Data_forecast))
+    
+  }else{
+    Data = get_data(cal_time_start = start_date, 
+                    cal_time_end = end_date, 
+                    model_timestep = model_timestep, # model timestep in days if filling in dates
+                    fill_dates = fill_dates,  # T/F for filling in dates w/o observations with NA's 
+                    sites = sites) %>%
+      mutate(daylength = daylength(43.4802, date))
+    
+    return(Data) 
+  }
+
   #2) return correct site - this is throwing an error - eliminating for now - MEL 10APR19
   #dat = eval(parse(text = sites))
-  
-  return(Data) 
 }
 
 jags_plug_ins <- function(model_name){


### PR DESCRIPTION
First cut at partitioning uncertainty for some of our Gloeo forecasts. I tried partitioning uncertainty for the random walk model, which wasn't too exciting because there aren't `drivers` or `parameters` for this model, so just `initial condition` and `process` uncertainty contribute to overall uncertainty. 
![image](https://user-images.githubusercontent.com/4825431/56537118-c08e5d80-652d-11e9-859a-31dc9fb8ed85.png)
I followed code referenced in issue #20, and I updated the `plug_n_play` functions so that it returns a forecast time period. The default is to not return a forecast time period, but you can now specify to return a forecast period and the last date of the forecast time frame (first date of forecast will start right after end date of calibration period). 